### PR TITLE
Update dependencies and deployment target

### DIFF
--- a/AlamofireSwiftyJSON.podspec
+++ b/AlamofireSwiftyJSON.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AlamofireSwiftyJSON"
-  s.version          = "1.0.1"
+  s.version          = "1.0.2"
   s.summary          = "Alamofire extension for serialize Data to SwiftyJSON "
   s.homepage         = "https://github.com/Xinguang/AlamofireSwiftyJSON"
   s.license = { :type => 'MIT', :file => 'LICENSE' }
@@ -12,10 +12,10 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
-  s.watchos.deployment_target = '2.0'
+  s.watchos.deployment_target = '3.0'
 
   s.requires_arc = true
   s.source_files = 'Source/*.swift'
-  s.dependency 'Alamofire', '~> 4.0'
-  s.dependency 'SwiftyJSON', '~> 4.0'
+  s.dependency 'Alamofire', '~> 4.7'
+  s.dependency 'SwiftyJSON', '~> 4.2'
 end

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Easy way to use both [Alamofire](https://github.com/Alamofire/Alamofire) and [Sw
 
 ## Requirements
 
-- iOS 8.0+ / macOS 10.10+ / tvOS 9.0+ / watchOS 2.0+
+- iOS 8.0+ / macOS 10.10+ / tvOS 9.0+ / watchOS 3.0+
 - Xcode 8.1+
 - Swift 3.0+
 


### PR DESCRIPTION
Updated to the latest versions of Alamofire and SwiftyJSON. SwiftyJSON now requires watchOS 3 as deployment target.